### PR TITLE
tracing: fast slow query tracing by omitting trace events

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1898,6 +1898,14 @@
                      "allowMultiple":false,
                      "type":"long",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"fast",
+                     "description":"Enables lightweight tracing mode: if true, tracing ignores all tracing events",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
                   }
                ]
             },
@@ -2396,6 +2404,10 @@
             "threshold":{
                "type":"long",
                "description":"The slow query logging threshold in microseconds. Queries that takes longer, will be logged"
+            },
+            "fast":{
+               "type":"boolean",
+               "description":"Is lightweight tracing mode enabled. In that mode tracing ignore events and tracks only sessions."
             }
          }
       },

--- a/configure.py
+++ b/configure.py
@@ -380,6 +380,7 @@ scylla_tests = set([
     'test/boost/schema_change_test',
     'test/boost/schema_registry_test',
     'test/boost/secondary_index_test',
+    'test/boost/tracing',
     'test/boost/index_with_paging_test',
     'test/boost/serialization_test',
     'test/boost/serialized_action_test',

--- a/test/boost/tracing.cc
+++ b/test/boost/tracing.cc
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * This file is part of Scylla.
+ *
+ * Scylla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Scylla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <seastar/testing/test_case.hh>
+
+#include "tracing/tracing.hh"
+#include "tracing/trace_state.hh"
+#include "tracing/tracing_backend_registry.hh"
+
+#include "test/lib/cql_test_env.hh"
+
+future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_test_config cfg_in = {}) {
+    return do_with_cql_env([func](auto &env) {
+        // supervisor::notify("creating tracing");
+        tracing::backend_registry tracing_backend_registry;
+        tracing::register_tracing_keyspace_backend(tracing_backend_registry);
+        tracing::tracing::create_tracing(tracing_backend_registry, "trace_keyspace_helper").get();
+
+        // supervisor::notify("starting tracing");
+        tracing::tracing::start_tracing(env.qp()).get();
+
+        return func(env).finally([](){
+            tracing::tracing::tracing_instance().invoke_on_all([] (tracing::tracing& local_tracing) {
+                return local_tracing.shutdown();
+            }).get();
+
+            return tracing::tracing::tracing_instance().stop();
+        });
+    }, std::move(cfg_in));
+}
+
+SEASTAR_TEST_CASE(tracing_respect_events) {
+    return do_with_tracing_env([](auto &e) {
+        tracing::tracing &t = tracing::tracing::get_local_tracing_instance();
+
+        t.set_ignore_trace_events(false);
+        BOOST_CHECK(!t.ignore_trace_events_enabled());
+
+        // create session
+        tracing::trace_state_props_set trace_props;
+        trace_props.set(tracing::trace_state_props::log_slow_query);
+        trace_props.set(tracing::trace_state_props::full_tracing);
+
+        tracing::trace_state_ptr trace_state1 = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::begin(trace_state1, "begin", gms::inet_address());
+
+        tracing::trace(trace_state1, "trace 1");
+        BOOST_CHECK_EQUAL(trace_state1->events_size(), 1);
+        BOOST_CHECK(tracing::make_trace_info(trace_state1) != std::nullopt);
+
+        // disable tracing events, it must be ignored for full tracing
+        t.set_ignore_trace_events(true);
+        BOOST_CHECK(t.ignore_trace_events_enabled());
+
+        tracing::trace_state_ptr trace_state2 = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::begin(trace_state2, "begin", gms::inet_address());
+
+        tracing::trace(trace_state2, "trace 1");
+        BOOST_CHECK_EQUAL(trace_state2->events_size(), 1);
+        BOOST_CHECK(tracing::make_trace_info(trace_state2) != std::nullopt);
+
+        return make_ready_future<>();
+    });
+}
+
+SEASTAR_TEST_CASE(tracing_slow_query_fast_mode) {
+    return do_with_tracing_env([](auto &e) {
+        tracing::tracing &t = tracing::tracing::get_local_tracing_instance();
+
+        // disable tracing events
+        t.set_ignore_trace_events(true);
+        BOOST_CHECK(t.ignore_trace_events_enabled());
+
+        // create session
+        tracing::trace_state_props_set trace_props;
+        trace_props.set(tracing::trace_state_props::log_slow_query);
+
+        tracing::trace_state_ptr trace_state = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::begin(trace_state, "begin", gms::inet_address());
+
+        // check no event created
+        tracing::trace(trace_state, "trace 1");
+        BOOST_CHECK_EQUAL(trace_state->events_size(), 0);
+        BOOST_CHECK(tracing::make_trace_info(trace_state) == std::nullopt);
+
+        return make_ready_future<>();
+    });
+}

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -226,6 +226,10 @@ public:
         return _records->my_span_id;
     }
 
+    uint64_t events_size() const {
+        return _records->events_recs.size();
+    }
+
 private:
     /**
      * Stop a foreground state and write pending records to I/O.

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -119,6 +119,9 @@ trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set p
             return nullptr;
         }
 
+        // Ignore events if they are disabled and this is not a full tracing request (probability tracing or user request)
+        props.set_if<trace_state_props::ignore_events>(!props.contains<trace_state_props::full_tracing>() && ignore_trace_events_enabled());
+
         ++_active_sessions;
         return make_lw_shared<trace_state>(type, props);
     } catch (...) {


### PR DESCRIPTION
The set of patches introduces a new tracing mode - `fast slow query tracing`. In this mode, Scylla tracks only tracing sessions and omits all tracing events if the tracing context does not have a `full_tracing` state set.

Fast tracing mode
---

To read status do

    $ curl -v http://localhost:10000/storage_service/slow_query

To enable fast slow query tracing

    $ curl -v --request POST http://localhost:10000/storage_service/slow_query\?fast=true\&enable=true

Potential optimizations
---

- remove tracing::begin(lazy_eval)
- replace tracing::begin(string) for enum to remove copying and memory allocations
- merge parameters allocations
- group parameters check for trace context
- delay formatting

Performance
---

100% cache hits
---

1GB memory, 1 Core:

    $ SCYLLA_HOME=/home/sitano.public/Projects/scylla build/release/scylla --smp 1 --cpuset 7 --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --network-stack posix --workdir /home/sitano.public/Projects/scylla --developer-mode 1 --listen-address 0.0.0.0 --api-address 0.0.0.0 --rpc-address 0.0.0.0 --broadcast-rpc-address 172.18.0.1 --broadcast-address 127.0.0.1

```
./cassandra-stress write n=100000 no-warmup -pop seq=1..100000 -node 127.0.0.1 -log level=verbose -rate threads=1 -mode native cql3

curl --request POST http://localhost:10000/storage_service/slow_query\?fast\=false\&enable\=false
for i in $(seq 5); do
  taskset -c 2,3,4,5 ./cassandra-stress read duration=5m -pop seq=1..100000 -node 127.0.0.1 -log level=verbose -rate threads=4 throttle=30000/s -mode native cql3
done

curl --request POST http://localhost:10000/storage_service/slow_query\?fast\=true\&enable\=true
for i in $(seq 5); do
  taskset -c 2,3,4,5 ./cassandra-stress read duration=5m -pop seq=1..100000 -node 127.0.0.1 -log level=verbose -rate threads=4 throttle=30000/s -mode native cql3
done

curl --request POST http://localhost:10000/storage_service/slow_query\?fast\=false\&enable\=true
for i in $(seq 5); do
  taskset -c 2,3,4,5 ./cassandra-stress read duration=5m -pop seq=1..100000 -node 127.0.0.1 -log level=verbose -rate threads=4 throttle=30000/s -mode native cql3
done
```

  | qps |   |   |  
-- | -- | -- | -- | --
  | baseline | fast, slow | nofast, slow | %[1-fastslow/baseline]
  | 29,018 | 26,468 | 23,591 | 8.79%
  | 28,909 | 26,274 | 23,584 | 9.11%
  | 28,900 | 26,547 | 23,598 | 8.14%
  | 28,921 | 26,669 | 23,596 | 7.79%
  | 28,821 | 26,385 | 23,601 | 8.45%
stdev | 70.24030182 | 150.9678774 | 6.670832032 |  
avg | 28,914 | 26,469 | 23,594 |  
stderr | 0.24% | 0.57% | 0.03% |  
%[avg/baseline] |   | **8.46%** | 18.40% |  

8.46% performance degradation in `fast slow query mode` for pure in-memory workload with minimum traces.
18.40%  performance degradation in `original slow query mode` for pure in-memory workload with minimum traces.

0% cache hits
---

1GB memory, 1 Core:

    $ SCYLLA_HOME=/home/sitano.public/Projects/scylla build/release/scylla --memory 1G --smp 1 --cpuset 7 --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --network-stack posix --workdir /home/sitano.public/Projects/scylla --developer-mode 1 --listen-address 0.0.0.0 --api-address 0.0.0.0 --rpc-address 0.0.0.0 --broadcast-rpc-address 172.18.0.1 --broadcast-address 127.0.0.1

2.4GB, 10000000 keys data:

    $ ./cassandra-stress write n=10000000 no-warmup -pop seq=1..10000000 -node 127.0.0.1 -log level=verbose -rate threads=4 -mode native cql3
    $ curl --request POST http://localhost:10000/storage_service/slow_query\?fast\=true\&enable\=true

CASSANDRA_STRESS prepared statements with BYPASS CACHE

    $ taskset -c 2,3,4,5 ./cassandra-stress read duration=5m -pop seq=1..10000000 -node 127.0.0.1 -log level=verbose -rate threads=4 throttle=30000/s -mode native cql3

20000 reads IOPS, 100MB/s from disk

  | qps |   |   |  
-- | -- | -- | -- | --
  | baseline reads | fast, slow reads | %[1-fastslow/baseline] |  
  | 9,575 | 9,054 | 5.44% |  
  | 9,614 | 9,065 | 5.71% |  
  | 9,610 | 9,066 | 5.66% |  
  | 9,611 | 9,062 | 5.71% |  
  | 9,614 | 9,073 | 5.63% |  
stdev | 16.75410397 | 6.892024376 |
avg | 9,605 | 9,064 |
stderr | 0.17% | 0.08% |
%[avg/baseline] |   | **5.63%** | 

5.63% performance degradation in `fast slow query mode` for pure on-disk workload with minimum traces.